### PR TITLE
Change public storage configuration to include public setting

### DIFF
--- a/files/config/storage.yml
+++ b/files/config/storage.yml
@@ -5,6 +5,7 @@ test:
 local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
+  public: <%= Decidim::Env.new("LOCAL_PUBLIC", "true").to_boolean_string %>
 
 s3:
   service: S3


### PR DESCRIPTION
The local storage service can also be configured to provide public urls, with this change we enable deployments to configure it based on the environment variable "LOCAL_PUBLIC", it defaults to true since the other service do the same.